### PR TITLE
fix helm name for open-github-from-file

### DIFF
--- a/helm-open-github.el
+++ b/helm-open-github.el
@@ -195,7 +195,7 @@
     (helm-open-github--from-file-action file start-line)))
 
 (defvar helm-open-github--from-file-source
-  '((name . "Open Github From Commit")
+  '((name . "Open Github From File")
     (init . helm-open-github--collect-files)
     (candidates-in-buffer)
     (action . (("Open File" .


### PR DESCRIPTION
fix name when executing open-github-from-file.  "Open Github From Commit" -> "Open Github From File"
