### PR TITLE
Closed issues fail with too many candidates.

### DIFF
--- a/helm-open-github.el
+++ b/helm-open-github.el
@@ -289,7 +289,7 @@
 
 (defvar helm-open-github--closed-issues-cache (make-hash-table :test 'equal))
 (defvar helm-open-github--from-closed-issues-source
-  (helm-build-in-buffer-source "Open Github From all Issues"
+  (helm-build-in-buffer-source "Open Github From closed Issues"
     :init (lambda ()
             (let* ((key (helm-open-github--remote-url))
                    (issues (gethash key helm-open-github--closed-issues-cache)))


### PR DESCRIPTION
Hi,
with too many candidates (helm) closed issues fail after trying to fetch candidates during long time,
(15 mn or so), it was working in the past.
I wonder why this:

- Something in gh is wrong (don't think so).

- Something in the API is wrong (don't think so).

- There is one issue somewhere in the helm repo that the API don't like
   and it hang forever on it.

I made some changes to workaround this problem by allowing customizing the number of days before for the closed issues.
While I was at it I changed the sort direction of closed issues (allow customizing) directly from API
instead of sorting the result once fetched.
The direction of the open issues have changed too but I didn't make it customizable and it is sorted as before (if you want to change this we have to write a new `defmethod`).

Cheers, Thierry.

